### PR TITLE
Never use MT1 position updates

### DIFF
--- a/2026-Code/src/main/java/frc/robot/subsystems/Vision.java
+++ b/2026-Code/src/main/java/frc/robot/subsystems/Vision.java
@@ -285,7 +285,7 @@ public class Vision extends SubsystemBase {
         return;
       } else if (!verifyPoseValidity() && verifyYawValidity()) {
         timestamp = estimateMT1.timestampSeconds;
-        pose = estimateMT1.pose;
+        return;
       } else if (verifyPoseValidity() && !verifyYawValidity()) {
         timestamp = estimateMT2.timestampSeconds;
         pose = estimateMT2.pose;


### PR DESCRIPTION
If MT2 doesn't see a tag but MT1 does we will accidentally update our position from MT1 when we really only intended to ever use MT1 for its yaw